### PR TITLE
fix(tags): push tags after initial push attempt

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,6 +80,10 @@ const bump = async () => {
         // update branch with changes
         core.debug(`Attempting to push to ${branch}`);
 
+        // first push without tags, in case this fails for some reason
+        await exec.exec(`git push "https://${actor}:${token}@github.com/${repo}" HEAD:${branch}`);
+
+        // then push with tags
         await exec.exec(`git push "https://${actor}:${token}@github.com/${repo}" HEAD:${branch} --tags`);
     
     } catch (error) {


### PR DESCRIPTION
Prevents tags being created when we cannot push to a branch for some reason